### PR TITLE
Replace dozer with modelmapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 		<jsonpath.version>0.9.1</jsonpath.version>
 		<openfeign-querydsl.version>5.6.1</openfeign-querydsl.version>
-		<dozer.version>5.5.1</dozer.version>
+		<modelmapper.version>3.2.2</modelmapper.version>
 		<commons-collection.version>3.2.2</commons-collection.version>
 		<ecs-logging-java.version>1.6.0</ecs-logging-java.version>
 		<jacoco.plugin.version>0.8.12</jacoco.plugin.version>
@@ -121,9 +121,9 @@
 			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.sf.dozer</groupId>
-			<artifactId>dozer</artifactId>
-			<version>${dozer.version}</version>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>${modelmapper.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign.querydsl</groupId>

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class ConnectionPointController {
 	private final Logger log = LoggerFactory.getLogger(ConnectionPointController.class);
 
 	private final ConnectionPointService connectionPointService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public ConnectionPointController(ConnectionPointService connectionPointService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.connectionPointService = connectionPointService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,10 +63,10 @@ public class CooperationController {
 
 	private final Logger log = LoggerFactory.getLogger(CooperationController.class);
 	private final CooperationService cooperationService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
-	public CooperationController(CooperationService cooperationService, DozerBeanMapper mapper) {
+	public CooperationController(CooperationService cooperationService, ModelMapper mapper) {
 		this.cooperationService = cooperationService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class InstalledContractController {
 	private final Logger log = LoggerFactory.getLogger(InstalledContractController.class);
 
 	private final InstalledContractService installedContractService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public InstalledContractController(InstalledContractService installedContractService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.installedContractService = installedContractService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class LogicalAddressController {
 	private final Logger log = LoggerFactory.getLogger(LogicalAddressController.class);
 
 	private final LogicalAddressService logicalAddressService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public LogicalAddressController(LogicalAddressService logicalAddressService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.logicalAddressService = logicalAddressService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class ServiceConsumerController {
 	private final Logger log = LoggerFactory.getLogger(ServiceConsumerController.class);
 
 	private final ServiceConsumerService serviceConsumerService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public ServiceConsumerController(ServiceConsumerService serviceConsumerService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.serviceConsumerService = serviceConsumerService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class ServiceContractController {
 	private final Logger log = LoggerFactory.getLogger(ServiceContractController.class);
 
 	private final ServiceContractService serviceContractService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public ServiceContractController(ServiceContractService serviceContractService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.serviceContractService = serviceContractService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class ServiceDomainController {
 	private final Logger log = LoggerFactory.getLogger(ServiceDomainController.class);
 
 	private final ServiceDomainService serviceDomainService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public ServiceDomainController(ServiceDomainService serviceDomainService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.serviceDomainService = serviceDomainService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,11 +54,11 @@ public class ServiceProducerController {
 	private final Logger log = LoggerFactory.getLogger(ServiceProducerController.class);
 
 	private final ServiceProducerService serviceProducerService;
-	private final DozerBeanMapper mapper;
+	private final ModelMapper mapper;
 
 	@Autowired
 	public ServiceProducerController(ServiceProducerService serviceProducerService,
-			DozerBeanMapper mapper) {
+			ModelMapper mapper) {
 		this.serviceProducerService = serviceProducerService;
 		this.mapper = mapper;
 	}

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
@@ -23,7 +23,7 @@ package se.skltp.cooperation.api.v2.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,7 +67,7 @@ public class ServiceProductionController {
 	private ServiceProductionService serviceProductionService;
 
 	@Autowired
-	private DozerBeanMapper mapper;
+	private ModelMapper mapper;
 
 	@Autowired
 	HTTPObfuscator httpObfuscator;

--- a/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
+++ b/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
@@ -20,27 +20,15 @@
  */
 package se.skltp.cooperation.config;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Mapping configuration
- *
- * @author Peter Merikan
- */
 @Configuration
 public class MappingConfiguration {
 
 	@Bean
-	public DozerBeanMapper mapper() {
-
-		List<String> mappingFiles = new ArrayList<>();
-		mappingFiles.add("dozerBeanMapping.xml");
-
-		return new DozerBeanMapper(mappingFiles);
+	public ModelMapper mapper() {
+		return new ModelMapper();
 	}
 }

--- a/src/main/resources/dozerBeanMapping.xml
+++ b/src/main/resources/dozerBeanMapping.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-					xmlns="http://dozer.sourceforge.net"
-					xsi:schemaLocation="http://dozer.sourceforge.net
-          http://dozer.sourceforge.net/schema/beanmapping.xsd">
-
-
-</mappings>

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -31,7 +31,7 @@
 		<Logger name="com.wordnik.swagger" level="WARN"/>
 		<Logger name="liquibase" level="WARN"/>
 		<Logger name="sun.rmi.transport" level="WARN"/>
-		<Logger name="org.dozer" level="WARN"/>
+		<Logger name="org.modelmapper" level="WARN"/>
 
     <Root level="INFO">
       <AppenderRef ref="CONSOLE"/>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -30,7 +30,7 @@
 		<Logger name="com.wordnik.swagger" level="WARN"/>
 		<Logger name="liquibase" level="WARN"/>
 		<Logger name="sun.rmi.transport" level="WARN"/>
-		<Logger name="org.dozer" level="WARN"/>
+		<Logger name="org.modelmapper" level="WARN"/>
 
     <Root level="WARN">
       <AppenderRef ref="CONSOLE"/>

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.catalina.security.SecurityConfig;
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -90,7 +90,7 @@ public class ConnectionPointControllerTest {
 	private ConnectionPointService connectionPointServiceMock;
 
 	@MockitoBean
-	private DozerBeanMapper mapperMock;
+	private ModelMapper mapperMock;
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
@@ -21,7 +21,7 @@
 package se.skltp.cooperation.api.v2.controller;
 
 import org.apache.catalina.security.SecurityConfig;
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,7 @@ public class CooperationControllerTest {
 	@MockitoBean
 	private CooperationService cooperationServiceMock;
 	@MockitoBean
-	private DozerBeanMapper mapperMock;
+	private ModelMapper mapperMock;
 	private MockMvc mockMvc;
 	private Cooperation c1;
 	private Cooperation c2;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,7 +73,7 @@ public class InstalledContractControllerTest {
 	@MockitoBean
 	private InstalledContractService installedContractServiceMock;
 	@MockitoBean
-	private DozerBeanMapper mapperMock;
+	private ModelMapper mapperMock;
 	private MockMvc mockMvc;
 
     @Autowired

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
@@ -21,7 +21,7 @@
 package se.skltp.cooperation.api.v2.controller;
 
 import org.apache.catalina.security.SecurityConfig;
-import org.dozer.DozerBeanMapper;
+import org.modelmapper.ModelMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,7 +76,7 @@ public class ServiceConsumerControllerTest {
 	@MockitoBean
 	private ServiceConsumerService serviceConsumerServiceMock;
 	@MockitoBean
-	private DozerBeanMapper mapperMock;
+	private ModelMapper mapperMock;
 	private MockMvc mockMvc;
 
 	private ServiceConsumer c1;


### PR DESCRIPTION
Dozer är inte längre aktivt förvaltad och drog med sig några dependencies med sårbarheter. Oväntat enkelt att byta ut mot modelmapper som stöder samma syntax:
`mapper.map(source, destination.class)`

Jag har inte hittat några icke-standard-mappningar i koden och inte stött på några problem hittills.