### PR TITLE
Feature/ntu 634 h2 console

### DIFF
--- a/src/main/java/se/skltp/cooperation/api/info/ControllerLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/ControllerLogger.java
@@ -1,0 +1,66 @@
+package se.skltp.cooperation.api.info;
+
+import jakarta.servlet.ServletContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
+@Component
+public class ControllerLogger implements ApplicationListener<ApplicationReadyEvent> {
+
+	private final Logger log = LoggerFactory.getLogger(ControllerLogger.class);
+	private final ServletContext servletContext;
+
+	public ControllerLogger(ServletContext servletContext) {
+		this.servletContext = servletContext;
+	}
+
+	@Override
+	public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
+		if (!log.isDebugEnabled()) {
+			return;
+		}
+		final String contextPath = getContextPath();
+		ApplicationContext context = event.getApplicationContext();
+
+		Map<String, Object> controllers = context.getBeansWithAnnotation(Controller.class);
+
+		log.debug("Controllers:");
+
+		controllers.values().forEach(controller -> {
+			Class<?> type = controller.getClass();
+			RequestMapping mapping = AnnotatedElementUtils.findMergedAnnotation(type, RequestMapping.class);
+
+			if (mapping != null) {
+				StringBuilder sb = new StringBuilder();
+				boolean first = true;
+				for (String path : mapping.value()) {
+					if (!first) {
+						sb.append(", ");
+					}
+					first = false;
+					sb.append(contextPath).append(path);
+				}
+				log.debug("  {} -> {}", sb, type.getSimpleName());
+			}
+		});
+	}
+
+	private String getContextPath() {
+		String contextPath = servletContext.getContextPath();
+		if (contextPath.endsWith("/")) {
+			contextPath = contextPath.substring(0, contextPath.length() - 1);
+		}
+		return contextPath;
+	}
+}
+

--- a/src/main/java/se/skltp/cooperation/api/info/ServletMappingLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/ServletMappingLogger.java
@@ -1,0 +1,43 @@
+package se.skltp.cooperation.api.info;
+
+import jakarta.servlet.ServletContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServletMappingLogger implements ApplicationListener<ApplicationReadyEvent> {
+
+	private final Logger log = LoggerFactory.getLogger(ServletMappingLogger.class);
+
+	private final ServletContext servletContext;
+
+	public ServletMappingLogger(ServletContext servletContext) {
+		this.servletContext = servletContext;
+	}
+
+	@Override
+	public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
+		if (!log.isDebugEnabled()) {
+			return;
+		}
+		var servletRegistrations = servletContext.getServletRegistrations();
+		final String contextPath = getContextPath();
+		if (!servletRegistrations.isEmpty()) {
+			log.debug("Servlets:");
+			servletContext.getServletRegistrations().forEach((name, registration) ->
+				registration.getMappings().forEach(mapping -> log.debug("  {}{} -> {}", contextPath, mapping, name)
+			));
+		}
+	}
+	private String getContextPath() {
+		String contextPath = servletContext.getContextPath();
+		if (contextPath.endsWith("/")) {
+			contextPath = contextPath.substring(0, contextPath.length() - 1);
+		}
+		return contextPath;
+	}
+}

--- a/src/main/java/se/skltp/cooperation/api/info/WebServerInfoLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/WebServerInfoLogger.java
@@ -1,0 +1,54 @@
+package se.skltp.cooperation.api.info;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+
+@Component
+public class WebServerInfoLogger implements ApplicationListener<WebServerInitializedEvent> {
+
+	private final Logger log = LoggerFactory.getLogger(WebServerInfoLogger.class);
+
+	private final String bindAddress;
+
+	public WebServerInfoLogger(@Value("${server.address:0.0.0.0}") String bindAddress) {
+		this.bindAddress = bindAddress;
+	}
+
+	@Override
+	public void onApplicationEvent(WebServerInitializedEvent event) {
+		int port = event.getWebServer().getPort();
+
+		log.info("Web server started:");
+
+		if (!"0.0.0.0".equals(bindAddress) && !"::".equals(bindAddress)) {
+			log.info("  {}:{}", bindAddress, port);
+			return;
+		}
+
+		try {
+			Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+			while (nets.hasMoreElements()) {
+				NetworkInterface iface = nets.nextElement();
+				if (!iface.isUp() || iface.isLoopback()) {
+					continue;
+				}
+
+				Enumeration<InetAddress> addrs = iface.getInetAddresses();
+				while (addrs.hasMoreElements()) {
+					InetAddress addr = addrs.nextElement();
+					log.info("  {}: {}:{}", iface.getName(), addr.getHostAddress(), port);
+				}
+			}
+		} catch (Exception e) {
+			log.warn("Could not enumerate interfaces", e);
+		}
+	}
+}

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
@@ -5,6 +5,7 @@
 
 package se.skltp.cooperation.basicauthmodule;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -36,7 +37,7 @@ public class BasicAuthConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http, @Value("${spring.h2.console.enabled:false}") boolean h2Console) throws Exception {
 		http
 
 			// !!! REGARDING CSRF PROTECTION !!!
@@ -47,29 +48,34 @@ public class BasicAuthConfig {
 			//   but only a API tools like Postman or Insomnia; CSRF protection is less relevant.
 			.csrf(AbstractHttpConfigurer::disable)
 
-			.authorizeHttpRequests(authz -> authz
-				// For the two versions of the primary API.
-				.requestMatchers(HttpMethod.GET, "/api/v2/**").hasAnyAuthority(Settings.REG_USER_ROLE, Settings.REG_ADMIN_ROLE, Settings.AUTH_ADMIN_ROLE)
-				.requestMatchers(HttpMethod.GET, "/api/v1/**").permitAll()
+			.authorizeHttpRequests(authz -> {
+				if (h2Console) { // Managing the H2 database in dev profile
+					authz.requestMatchers("/h2-console/**").permitAll();
+				}
+				authz
+					// For the two versions of the primary API.
+					.requestMatchers(HttpMethod.GET, "/api/v2/**").hasAnyAuthority(Settings.REG_USER_ROLE, Settings.REG_ADMIN_ROLE, Settings.AUTH_ADMIN_ROLE)
+					.requestMatchers(HttpMethod.GET, "/api/v1/**").permitAll()
 
-				// The swagger Docs are open outward.
-				.requestMatchers(HttpMethod.GET, "/doc/**").permitAll()
+					// The swagger Docs are open outward.
+					.requestMatchers(HttpMethod.GET, "/doc/**").permitAll()
 
-				// Actuator endpoints does not require authentication (should only be reachable internally)
-				.requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
+					// Actuator endpoints does not require authentication (should only be reachable internally)
+					.requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
 
-				// Ping always responds openly.
-				.requestMatchers(HttpMethod.GET, "/authoring/ping").permitAll()
+					// Ping always responds openly.
+					.requestMatchers(HttpMethod.GET, "/authoring/ping").permitAll()
 
-				// Roles assumed to inherit hierarchically.
-				.requestMatchers(HttpMethod.GET, "/authoring/admin/**").hasAnyAuthority(Settings.AUTH_ADMIN_ROLE)
-				.requestMatchers(HttpMethod.POST, "/authoring/admin/**").hasAnyAuthority(Settings.AUTH_ADMIN_ROLE)
+					// Roles assumed to inherit hierarchically.
+					.requestMatchers(HttpMethod.GET, "/authoring/admin/**").hasAnyAuthority(Settings.AUTH_ADMIN_ROLE)
+					.requestMatchers(HttpMethod.POST, "/authoring/admin/**").hasAnyAuthority(Settings.AUTH_ADMIN_ROLE)
 
-				// Default level for all other endpoints is assumed restricted, as fallback.
-				.requestMatchers(HttpMethod.GET, "/**").hasAnyAuthority(Settings.REG_USER_ROLE, Settings.REG_ADMIN_ROLE, Settings.AUTH_ADMIN_ROLE)
-				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Options always open tho'.
+					// Default level for all other endpoints is assumed restricted, as fallback.
+					.requestMatchers(HttpMethod.GET, "/**").hasAnyAuthority(Settings.REG_USER_ROLE, Settings.REG_ADMIN_ROLE, Settings.AUTH_ADMIN_ROLE)
+					.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Options always open tho'.
 
-				.anyRequest().fullyAuthenticated())
+					.anyRequest().fullyAuthenticated();
+			})
 			.httpBasic(Customizer.withDefaults())
 			.exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(authenticationEntryPoint()));
 		return http.build();
@@ -91,7 +97,6 @@ public class BasicAuthConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return web -> web
-			.httpFirewall(constructFairlyOpenFirewall())
-			.ignoring().requestMatchers("/h2-console/**");
+			.httpFirewall(constructFairlyOpenFirewall());
 	}
 }


### PR DESCRIPTION
- Konfiguration av åtkomst till H2 console flyttad från WebSecurityCustomizer till SecurityFilterChain
  - Endast om spring.h2.console.enabled, så i praktiken bara i dev-profil.
- Tillagt några uppstartslyssnare för att få en överblick över exponerade interface och end-points.
