### PR TITLE
Upgrade to Java 21, with extras.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 ENV BASE_DIR=/opt/cooperation/ \
     APP_USER=cooperation

--- a/Jenkins.properties
+++ b/Jenkins.properties
@@ -1,5 +1,5 @@
 sonar.projectkey=ntjp-cooperation
-jdk.path=openjdk-17
+jdk.path=openjdk-21
 artifact.version=1.9.0-SNAPSHOT
 release.profile=rivta
 main.branch=main

--- a/License.md
+++ b/License.md
@@ -2,8 +2,10 @@
 Also known as _TAK-API_.
 
 Copyright © 2015–2026. Inera, Sweden.
+https://www.inera.se/
 
-This project/library is part of the SKLTP project and software kit.
+This project/library uses parts of the SKLTP project and libraries.
+https://inera.atlassian.net/wiki/spaces/SKLTP/overview
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -15,7 +17,6 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 Lesser General Public License for more details.
 
-You have received a copy of the GNU Lesser General Public
-License along with this library. <br>
+You have received a copy of the GNU Lesser General Public License along with this library.<br>
 Please see the separate license file: `License_GNU_LGPL-2.1.md`.<br>
 Alternatively, you can download the license file here: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.md

--- a/License.md
+++ b/License.md
@@ -1,0 +1,21 @@
+## Cooperation
+Also known as _TAK-API_.
+
+Copyright © 2015–2026. Inera, Sweden.
+
+This project/library is part of the SKLTP project and software kit.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You have received a copy of the GNU Lesser General Public
+License along with this library. <br>
+Please see the separate license file: `License_GNU_LGPL-2.1.md`.<br>
+Alternatively, you can download the license file here: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.md

--- a/License_GNU_LGPL-2.1.md
+++ b/License_GNU_LGPL-2.1.md
@@ -1,0 +1,502 @@
+# GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+    Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+    <https://fsf.org/>
+    
+    Everyone is permitted to copy and distribute verbatim copies
+    of this license document, but changing it is not allowed.
+
+    [This is the first released version of the Lesser GPL.  It also counts
+     as the successor of the GNU Library Public License, version 2, hence
+     the version number 2.1.]
+
+## Preamble
+
+The licenses for most software are designed to take away your freedom
+to share and change it. By contrast, the GNU General Public Licenses
+are intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it. You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations
+below.
+
+When we speak of free software, we are referring to freedom of use,
+not price. Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights. These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you. You must make sure that they, too, receive or can get the source
+code. If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there
+is no warranty for the free library. Also, if the library is modified
+by someone else and passed on, the recipients should know that what
+they have is not the original version, so that the original author's
+reputation will not be affected by problems that might be introduced
+by others.
+
+Finally, software patents pose a constant threat to the existence of
+any free program. We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder. Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License. This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License. We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a
+shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library. The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom. The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License. It also provides other free software developers Less
+of an advantage over competing non-free programs. These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries. However, the Lesser license provides advantages in certain
+special circumstances.
+
+For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it
+becomes a de-facto standard. To achieve this, non-free programs must
+be allowed to use the library. A more frequent case is that a free
+library does the same job as widely used non-free libraries. In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software. For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and
+modification follow. Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library". The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+## TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+**0.** This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License"). Each
+licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work
+which has been distributed under these terms. A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language. (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for
+making modifications to it. For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control
+compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it). Whether that is true depends on what the Library does and
+what the program that uses the Library does.
+
+**1.** You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a
+fee.
+
+**2.** You may modify your copy or copies of the Library or any
+portion of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+-   **a)** The modified work must itself be a software library.
+-   **b)** You must cause the files modified to carry prominent
+    notices stating that you changed the files and the date of
+    any change.
+-   **c)** You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+-   **d)** If a facility in the modified Library refers to a function
+    or a table of data to be supplied by an application program that
+    uses the facility, other than as an argument passed when the
+    facility is invoked, then you must make a good faith effort to
+    ensure that, in the event an application does not supply such
+    function or table, the facility still operates, and performs
+    whatever part of its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of
+    the application. Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+**3.** You may opt to apply the terms of the ordinary GNU General
+Public License instead of this License to a given copy of the Library.
+To do this, you must alter all the notices that refer to this License,
+so that they refer to the ordinary GNU General Public License, version
+2, instead of to this License. (If a newer version than version 2 of
+the ordinary GNU General Public License has appeared, then you can
+specify that version instead if you wish.) Do not make any other
+change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that
+copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the
+Library into a program that is not a library.
+
+**4.** You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from
+a designated place, then offering equivalent access to copy the source
+code from the same place satisfies the requirement to distribute the
+source code, even though third parties are not compelled to copy the
+source along with the object code.
+
+**5.** A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library". Such a work,
+in isolation, is not a derivative work of the Library, and therefore
+falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library". The executable is therefore covered by this License. Section
+6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library. The
+threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure
+layouts and accessors, and small macros and small inline functions
+(ten lines or less in length), then the use of the object file is
+unrestricted, regardless of whether it is legally a derivative work.
+(Executables containing this object code plus portions of the Library
+will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+**6.** As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a work
+containing portions of the Library, and distribute that work under
+terms of your choice, provided that the terms permit modification of
+the work for the customer's own use and reverse engineering for
+debugging such modifications.
+
+You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License. You must supply a copy of this License. If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License. Also, you must do one
+of these things:
+
+-   **a)** Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library. (It is understood that
+    the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+-   **b)** Use a suitable shared library mechanism for linking with
+    the Library. A suitable mechanism is one that (1) uses at run time
+    a copy of the library already present on the user's computer
+    system, rather than copying library functions into the executable,
+    and (2) will operate properly with a modified version of the
+    library, if the user installs one, as long as the modified version
+    is interface-compatible with the version that the work was
+    made with.
+-   **c)** Accompany the work with a written offer, valid for at least
+    three years, to give the same user the materials specified in
+    Subsection 6a, above, for a charge no more than the cost of
+    performing this distribution.
+-   **d)** If distribution of the work is made by offering access to
+    copy from a designated place, offer equivalent access to copy the
+    above specified materials from the same place.
+-   **e)** Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it. However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system. Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+**7.** You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+-   **a)** Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other
+    library facilities. This must be distributed under the terms of
+    the Sections above.
+-   **b)** Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+**8.** You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License. Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License. However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+**9.** You are not required to accept this License, since you have not
+signed it. However, nothing else grants you permission to modify or
+distribute the Library or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+**10.** Each time you redistribute the Library (or any work based on
+the Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions. You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+**11.** If, as a consequence of a court judgment or allegation of
+patent infringement or for any other reason (not limited to patent
+issues), conditions are imposed on you (whether by court order,
+agreement or otherwise) that contradict the conditions of this
+License, they do not excuse you from the conditions of this License.
+If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations,
+then as a consequence you may not distribute the Library at all. For
+example, if a patent license would not permit royalty-free
+redistribution of the Library by all those who receive copies directly
+or indirectly through you, then the only way you could satisfy both it
+and this License would be to refrain entirely from distribution of the
+Library.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply, and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices. Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+**12.** If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded. In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+**13.** The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time. Such
+new versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation. If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+**14.** If you wish to incorporate parts of the Library into other
+free programs whose distribution conditions are incompatible with
+these, write to the author to ask for permission. For software which
+is copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this. Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+**NO WARRANTY**
+
+**15.** BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+**16.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+## How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change. You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms
+of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It
+is safest to attach them to the start of each source file to most
+effectively convey the exclusion of warranty; and each file should
+have at least the "copyright" line and a pointer to where the full
+notice is found.
+
+    one line to give the library's name and an idea of what it does.
+    Copyright (C) year  name of author
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper
+mail.
+
+You should also get your employer (if you work as a programmer) or
+your school, if any, to sign a "copyright disclaimer" for the library,
+if necessary. Here is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in
+    the library `Frob' (a library for tweaking knobs) written
+    by James Random Hacker.
+
+    signature of Moe Ghoul, 1 April 1990
+    Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.11</version>
+    <version>3.5.12</version>
     <relativePath/>
   </parent>
 
@@ -52,7 +52,7 @@
 
   <properties>
 		<java.version>21</java.version>
-		<spring-boot.version>3.5.11</spring-boot.version> <!-- From Feb 2026 -->
+		<spring-boot.version>3.5.12</spring-boot.version> <!-- From Mar 2026 -->
 
     <jacoco.plugin.version>0.8.14</jacoco.plugin.version> <!-- From Oct 2025 -->
     <modelmapper.version>3.2.6</modelmapper.version> <!-- From Nov 2025 -->
@@ -138,6 +138,12 @@
 			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
@@ -183,11 +189,6 @@
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
 			<!-- VERSION handled by Spring Boot Dependencies BOM -->
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.1</version>
-    <relativePath></relativePath>
+    <version>3.5.11</version>
+    <relativePath/>
   </parent>
+
   <groupId>se.skltp.cooperation</groupId>
   <artifactId>cooperation</artifactId>
   <version>1.9.0-SNAPSHOT</version>
+
   <name>cooperation</name>
   <description>Established Cooperation</description>
+	<url/>
+	<inceptionYear/>
+	<organization/>
+	<licenses/>
+
+	<developers/>
+	<contributors/>
+
+	<mailingLists/>
+
+	<!-- The prerequisites tag is only intended for maven-plugin projects. -->
+	<!--prerequisites/-->
+
+	<modules/>
+
   <scm>
     <connection>scm:git:https://github.com:443/skltp-integration/cooperation.git</connection>
     <developerConnection>scm:git:https://github.com:443/skltp-integration/cooperation.git</developerConnection>
     <url>https://github.com/skltp-integration/cooperation.git</url>
   </scm>
+	<issueManagement/>
+	<ciManagement/>
   <distributionManagement>
     <repository>
       <id>release-nexus</id>
@@ -30,31 +49,48 @@
       <url>${snapshot-nexus-url}</url>
     </snapshotRepository>
   </distributionManagement>
+
   <properties>
-    <commons-collection.version>3.2.2</commons-collection.version>
-    <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
-    <java.version>17</java.version>
-    <jakarta.xml.version>4.0.2</jakarta.xml.version>
-    <modelmapper.version>3.2.2</modelmapper.version>
-    <build.timestamp>${maven.build.timestamp}</build.timestamp>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <ecs-logging-java.version>1.5.0</ecs-logging-java.version>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-    <gson.version>2.11.0</gson.version>
-    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <openfeign-querydsl.version>5.6.1</openfeign-querydsl.version>
-    <jsonpath.version>0.9.1</jsonpath.version>
+		<java.version>21</java.version>
+		<spring-boot.version>3.5.11</spring-boot.version> <!-- From Feb 2026 -->
+
+    <jacoco.plugin.version>0.8.14</jacoco.plugin.version> <!-- From Oct 2025 -->
+    <modelmapper.version>3.2.6</modelmapper.version> <!-- From Nov 2025 -->
+		<openfeign-querydsl.version>6.12</openfeign-querydsl.version> <!-- From Jun 2025 -->
+
+    <ecs-logging-java.version>1.7.0</ecs-logging-java.version> <!-- From Apr 2025 -->
+
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+		<build.timestamp>${maven.build.timestamp}</build.timestamp>
   </properties>
+
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>${commons-collection.version}</version>
-      </dependency>
+			<!-- Importing Spring Boot BOM-POM, which sets versions for a ton of Spring-related dependencies. -->
+			<!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<!-- Source: https://mvnrepository.com/artifact/io.github.openfeign.querydsl/querydsl-bom -->
+			<dependency>
+				<groupId>io.github.openfeign.querydsl</groupId>
+				<artifactId>querydsl-bom</artifactId>
+				<version>${openfeign-querydsl.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -85,11 +121,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>${gson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
@@ -102,6 +133,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
+		</dependency>
+
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
@@ -119,32 +155,25 @@
       <artifactId>modelmapper</artifactId>
       <version>${modelmapper.version}</version>
     </dependency>
+
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>${openfeign-querydsl.version}</version>
-      <classifier>jakarta</classifier>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.github.openfeign.querydsl</groupId>
-      <artifactId>querydsl-jpa</artifactId>
-      <version>${openfeign-querydsl.version}</version>
       <classifier>jakarta</classifier>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
-    </dependency>
+		<!-- Source: https://mvnrepository.com/artifact/io.github.openfeign.querydsl/querydsl-jpa -->
+		<dependency>
+			<groupId>io.github.openfeign.querydsl</groupId>
+			<artifactId>querydsl-jpa</artifactId>
+		</dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
+			<!-- VERSION handled by Spring Boot Dependencies BOM -->
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-    </dependency>
+
+
     <dependency>
       <groupId>co.elastic.logging</groupId>
       <artifactId>log4j2-ecs-layout</artifactId>
@@ -153,45 +182,34 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${jakarta.xml.version}</version>
+			<!-- VERSION handled by Spring Boot Dependencies BOM -->
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
+			<!-- VERSION handled by Spring Boot Dependencies BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
+			<!-- VERSION handled by Spring Boot Dependencies BOM -->
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.5</version>
-    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
+
   <build>
     <finalName>cooperation-${project.version}</finalName>
     <pluginManagement>
@@ -212,9 +230,9 @@
           <version>1.10.b1</version>
           <configuration>
             <properties>
-              <year>2014</year>
-              <copyright>Center for eHalsa i samverkan (CeHis).
-								&lt;http://cehis.se/></copyright>
+              <year>2014-2026</year>
+              <copyright>Inera.
+								&lt;https://inera.se/></copyright>
               <product>SKLTP</product>
             </properties>
             <strictCheck>true</strictCheck>
@@ -243,7 +261,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+				<!-- VERSION handled by Spring Boot Dependencies BOM -->
         <configuration>
           <release>${java.version}</release>
         </configuration>
@@ -253,12 +271,15 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
           <arguments>
-            <argument>--spring.profiles.active=dev</argument>
+            <argument>--spring.profiles.active=prod</argument>
           </arguments>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+	<reporting/>
+
   <profiles>
     <profile>
       <id>license</id>

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM groovy:4.0-jdk17
+FROM groovy:4.0-jdk21
 
 USER root
 RUN apt update && apt install -y mailutils openssh-client

--- a/src/main/java/se/skltp/cooperation/Application.java
+++ b/src/main/java/se/skltp/cooperation/Application.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation;

--- a/src/main/java/se/skltp/cooperation/Application.java
+++ b/src/main/java/se/skltp/cooperation/Application.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/Application.java
+++ b/src/main/java/se/skltp/cooperation/Application.java
@@ -1,58 +1,28 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.annotation.PropertySources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-// cooperation-config-override.properties file is for tomcat production deployment
-// should contain
-// spring.datasource.url=jdbc:mysql://localhost/cooperation
-// spring.datasource.username=root
-// spring.datasource.testOnBorrow: true
-// spring.datasource.validationQuery: SELECT 1
-// spring.datasource.password=
-
-// these properties are left out of the application.yml in the prod profile section
-//
-// tomcat bin directory should contain a setenv.sh containing
-// export CATALINA_OPTS="$CATALINA_OPTS -Dspring.profiles.active=prod"
-// export CATALINA_OPTS="$CATALINA_OPTS -Dapp.conf.dir=/Users/jan/conf"
-// the cooperation-config-override.properties should be placed in the directory pointed out in the last row above
-
 @SpringBootApplication
-@PropertySources({
-    @PropertySource(value = "file:${app.conf.dir}/cooperation-config-override.properties", ignoreResourceNotFound = true)
-})
 @EnableScheduling
 public class Application extends SpringBootServletInitializer {
+	private final static  Logger log = LoggerFactory.getLogger(Application.class);
 
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
@@ -60,6 +30,7 @@ public class Application extends SpringBootServletInitializer {
     }
 
 	public static void main(String[] args) {
+		log.info("Spring Boot Launching - running version: {}", SpringBootVersion.getVersion());
 		SpringApplication.run(Application.class, args);
 	}
 

--- a/src/main/java/se/skltp/cooperation/api/Version1Gone.java
+++ b/src/main/java/se/skltp/cooperation/api/Version1Gone.java
@@ -6,13 +6,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * This is a basic catch-all Response to tell any callers that an API has been closed.
+ */
 @RestController
 @RequestMapping(value = {
 	"/api/v1/**"
 })
-/**
- * This is a basic catch-all Response to tell any callers that an API has been closed.
- */
 public class Version1Gone {
 	@GetMapping()
 	public ResponseEntity<String> respondWithGone() {

--- a/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;

--- a/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;

--- a/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -23,7 +23,6 @@ package se.skltp.cooperation.api.exception;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
- * @author Peter Merikan
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class FieldError {

--- a/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;

--- a/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  *
  * @see <a href="http://tools.ietf.org/html/draft-nottingham-http-problem-00">draft-nottingham-http-problem-00</a>
  *
- * @author Peter Merikan
  */
 @XmlRootElement(name="problem")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;

--- a/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -23,7 +23,6 @@ package se.skltp.cooperation.api.exception;
 /**
  * Exception class
  *
- * @author Peter Merikan
  */
 public class ResourceNotFoundException extends RuntimeException {
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  *
- * @author Peter Merikan
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ValidationError extends ProblemDetail{

--- a/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -40,7 +40,6 @@ import se.skltp.cooperation.api.v2.listdto.ConnectionPointListDTO;
 /**
  * REST controller for managing ConnectionPoint.
  *
- * @author Peter Merikan
  */
 @RestController
 @RequestMapping(value = {

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import se.skltp.cooperation.api.exception.ResourceNotFoundException;
@@ -37,14 +38,12 @@ import se.skltp.cooperation.domain.Cooperation;
 import se.skltp.cooperation.service.CooperationCriteria;
 import se.skltp.cooperation.service.CooperationService;
 
+import se.skltp.cooperation.util.ControllerUtils;
 import se.skltp.cooperation.util.TimeDiffUtil;
-
-import com.google.common.base.Splitter;
 
 /**
  * REST controller to handle resource Cooperation
  *
- * @author Peter Merikan
  */
 @RestController
 @RequestMapping(value = {
@@ -55,7 +54,7 @@ import com.google.common.base.Splitter;
 })
 public class CooperationController {
 
-	private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
 	static final String INCLUDE_SERVICECONSUMER = "serviceConsumer";
 	private static final String INCLUDE_SERVICECONTRACT = "serviceContract";
 	private static final String INCLUDE_CONNECTIONPOINT = "connectionPoint";
@@ -131,7 +130,7 @@ public class CooperationController {
 
 		List<String> includes = new ArrayList<>();
 		if (include != null) {
-			includes.addAll(SPLITTER.splitToList(include));
+			includes.addAll(ControllerUtils.splitCommaSeparated(include));
 		}
 
 		CooperationCriteria criteria = new CooperationCriteria(serviceConsumerId, logicalAddressId,

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
@@ -1,21 +1,8 @@
 /**
- * Copyright 2014-2026, Inera.
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright 2014-2026, Inera.
  *
  * This file is part of SKLTP.
  *
@@ -40,7 +39,6 @@ import se.skltp.cooperation.service.ServiceConsumerService;
 /**
  * REST controller for managing ServiceConsumer.
  *
- * @author Peter Merikan
  */
 @RestController
 @RequestMapping(value = {

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -37,8 +37,7 @@ import se.skltp.cooperation.api.exception.ResourceNotFoundException;
 import se.skltp.cooperation.api.v2.dto.ServiceProductionDTO;
 import se.skltp.cooperation.api.v2.format.HTTPObfuscator;
 import se.skltp.cooperation.api.v2.listdto.ServiceProductionListDTO;
-
-import com.google.common.base.Splitter;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * REST controller to handle resource ServiceProduction
@@ -54,7 +53,7 @@ import com.google.common.base.Splitter;
 })
 public class ServiceProductionController {
 
-	private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
 	private static final String INCLUDE_PHYSICAL_ADDRESS = "physicalAddress";
 	public static final String INCLUDE_SERVICEPRODUCER = "serviceProducer";
 	public static final String INCLUDE_SERVICECONTRACT = "serviceContract";
@@ -142,7 +141,7 @@ public class ServiceProductionController {
 
 		List<String> includes = new ArrayList<>();
 		if (include != null) {
-			includes.addAll(SPLITTER.splitToList(include));
+			includes.addAll(ControllerUtils.splitCommaSeparated(include));
 		}
 
 		ServiceProductionCriteria criteria = new ServiceProductionCriteria(physicalAddress,

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A ConnectionPoint Data Transfer Object
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "connectionPoint")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A Cooperation Data Transfer Object with associations
  *
- * @author Peter Merikan
  */
 
 @JacksonXmlRootElement(localName = "cooperation")

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  * A ServiceContract Data Transfer Object
  * Minor version in omitted from this class and the rest output
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "installedContract")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A LogicalAddress Data Transfer Object
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "logicalAddress")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A ServiceConsumer Data Transfer Object
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "serviceConsumer")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  * A ServiceContract Data Transfer Object
  * Minor version in omitted from this class and the rest output
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "serviceContract")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A ServiceProducer Data Transfer Object
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "serviceProducer")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A ServiceProduction Data Transfer Object with associations
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName = "serviceProduction")
 @JsonInclude(Include.NON_EMPTY)

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A wrapper object to hold a list of {@link ConnectionPointDTO} objects.
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName="connectionPoints")
 public class ConnectionPointListDTO {

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A wrapper object to hold a list of {@link CooperationDTO} objects.
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName="cooperations")
 public class CooperationListDTO {

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A wrapper object to hold a list of {@link ServiceConsumerDTO} objects.
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName="serviceConsumers")
 public class ServiceConsumerListDTO {

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A wrapper object to hold a list of {@link ServiceProducerDTO} objects.
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName="serviceProducers")
 public class ServiceProducerListDTO {

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * A wrapper object to hold a list of {@link ServiceProductionDTO} objects.
  *
- * @author Peter Merikan
  */
 @JacksonXmlRootElement(localName="serviceProductions")
 public class ServiceProductionListDTO {

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
@@ -45,7 +45,7 @@ public class BasicAuthConfig {
 			//   Our motivation is that CSRF attack protection is mostly relevant when a browser is involved,
 			//   where an attacker page can exploit a user's pre-existing session cookie or some other stored token.
 			// For stateless APIs, that communicate backend-backend; or where requests are never made from a browser,
-			//   but only a API tools like Postman or Insomnia; CSRF protection is less relevant.
+			//   but only via API tools like Postman or Insomnia; CSRF protection is less relevant.
 			.csrf(AbstractHttpConfigurer::disable)
 
 			.authorizeHttpRequests(authz -> {

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
@@ -1,6 +1,6 @@
 //////
 // 2022-05-17, Henrik Augustsson.
-// Nordic Medtest.
+// Inera.
 //////
 
 package se.skltp.cooperation.basicauthmodule;
@@ -25,13 +25,17 @@ public final class ServiceUserManagement {
 
 	private final Logger log = LoggerFactory.getLogger(ServiceUserManagement.class);
 
-	@Autowired
 	UserRepository userRepository;
+
+	@Autowired
+	ServiceUserManagement(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
 
 	@PostConstruct
 	private void initialization() {
 		log.debug("INITIALIZATION of ServiceUserManagement instance.");
-		if (userRepository.findAll().size() == 0) {
+		if (userRepository.findAll().isEmpty()) {
 			log.info("ADDING CAESAR as generic auth user. Change in DB.");
 			createUserFlow(new UserData(
 				"Caesar",
@@ -93,7 +97,7 @@ public final class ServiceUserManagement {
 	/**
 	 * Checks if User is present by name.
 	 * @param username The username (id) of the user.
-	 * @return true if user exists in the db, false otherwise.
+	 * @return true if the user exists in the db, false otherwise.
 	 */
 	public boolean userExists(String username) {
 		return userRepository.existsById(username);
@@ -103,7 +107,7 @@ public final class ServiceUserManagement {
 		// At the entry of this function, it is already known that the user does not exist.
 		// Any permission settings were checked in the controller.
 
-		log.info("Attempting CREATION of USER " + newUserPayload.username + " with roles: " + newUserPayload.roles);
+		log.info("Attempting CREATION of USER {} with roles: {}", newUserPayload.username, newUserPayload.roles);
 
 		newUserPayload.password = MyUserDetailsService.generateHashedPassword(newUserPayload.password);
 
@@ -114,10 +118,10 @@ public final class ServiceUserManagement {
 
 	public ServiceUser editUserFlow(UserData incomingUserData, ServiceUser existingUser) {
 		// At the entry of this function, it is already known that the user exists.
-		//   The specific user entry was located in the controller function, and attached to this call.
+		//   The specific user entry was located in the controller function and attached to this call.
 		// Any permission settings were checked in the controller.
 
-		log.info("Attempting EDIT of USER " + incomingUserData.username + ", which will have provided roles: " + incomingUserData.roles);
+		log.info("Attempting EDIT of USER {}, which will have provided roles: {}", incomingUserData.username, incomingUserData.roles);
 
 		ServiceUser editedUser = new ServiceUser(
 			existingUser.username,
@@ -137,7 +141,7 @@ public final class ServiceUserManagement {
 		// At the entry of this function, password quality has been checked,
 		//    and any permission settings were checked in the controller.
 
-		log.info("Attempting PWD CHANGE on USER " + existingUser.username + " with current roles: " + existingUser.roles);
+		log.info("Attempting PWD CHANGE on USER {} with current roles: {}", existingUser.username, existingUser.roles);
 
 		String hashedPassword = MyUserDetailsService.generateHashedPassword(newPassword);
 
@@ -171,8 +175,7 @@ public final class ServiceUserManagement {
 
 	/**
 	 * Will assemble a wrapper of dummy users.\n
-	 * Will not be stored in memory.\n
-	 * Will not overwrite user file.
+	 * Will not be stored in memory.
 	 * Do NOT use these Dummy users for actual service usage, for obvious security reasons.
 	 *
 	 * @return A payload of dummy users.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
@@ -5,8 +5,6 @@
 
 package se.skltp.cooperation.basicauthmodule;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,8 +27,6 @@ public final class ServiceUserManagement {
 
 	@Autowired
 	UserRepository userRepository;
-
-	private static final Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
 
 	@PostConstruct
 	private void initialization() {

--- a/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
+++ b/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.config;

--- a/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
+++ b/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.config;
 

--- a/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
+++ b/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
+++ b/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
+++ b/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -30,7 +30,6 @@ import jakarta.persistence.*;
 /**
  * A ConnectionPoint.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "CONNECTIONPOINT")

--- a/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
+++ b/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/Cooperation.java
+++ b/src/main/java/se/skltp/cooperation/domain/Cooperation.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -26,7 +26,6 @@ import java.io.Serializable;
 /**
  * A Cooperation.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "COOPERATION")

--- a/src/main/java/se/skltp/cooperation/domain/Cooperation.java
+++ b/src/main/java/se/skltp/cooperation/domain/Cooperation.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/Cooperation.java
+++ b/src/main/java/se/skltp/cooperation/domain/Cooperation.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
+++ b/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -28,7 +28,6 @@ import java.util.Set;
 /**
  * A LogicalAddress.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "LOGICALADDRESS")

--- a/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
+++ b/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
+++ b/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,6 @@ import java.util.Set;
 /**
  * A ServiceConsumer.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "SERVICECONSUMER")

--- a/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,6 @@ import java.util.Set;
 /**
  * A ServiceContract.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "SERVICECONTRACT")

--- a/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,6 @@ import java.util.Set;
 /**
  * A ServiceProducer.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "SERVICEPRODUCER")

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -26,7 +26,6 @@ import java.io.Serializable;
 /**
  * A ServiceProduction.
  *
- * @author Peter Merikan
  */
 @Entity
 @Table(name = "SERVICEPRODUCTION")

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,13 +29,13 @@ public class ConnectionPointCriteria {
 	Long logicalAddressId;
 	Long serviceContractId;
 	Long serviceProducerId;
-	
+
 	public boolean isEmpty() {
 
 		return environment == null && platform == null && serviceConsumerId == null && logicalAddressId == null
 			&& serviceContractId == null && serviceProducerId == null;
 	}
-	
+
 	public ConnectionPointCriteria(String environment, String platform, Long serviceConsumerId,
 			Long logicalAddressId, Long serviceContractId, Long serviceProducerId) {
 		super();

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -25,13 +25,12 @@ import java.util.List;
 import se.skltp.cooperation.domain.ConnectionPoint;
 
 /**
- * @author Peter Merikan
  */
 public interface ConnectionPointService {
 
 	/**
 	 * Find all ConnectionPoints
-	 * 
+	 *
 	 * @param criteria
 	 *
 	 * @return List A list of {@link ConnectionPoint} objects.

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -23,7 +23,6 @@ package se.skltp.cooperation.service;
 /**
  * A criteria object to be used when fetching Cooperations
  *
- * @author Peter Merikan
  */
 public class CooperationCriteria {
 
@@ -90,6 +89,6 @@ public class CooperationCriteria {
 	public void setServiceDomainId(Long serviceDomainId) {
 		this.serviceDomainId = serviceDomainId;
 	}
-	
-	
+
+
 }

--- a/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/CooperationService.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -25,7 +25,6 @@ import se.skltp.cooperation.domain.Cooperation;
 import java.util.List;
 
 /**
- * @author Peter Merikan
  */
 public interface CooperationService {
 

--- a/src/main/java/se/skltp/cooperation/service/CooperationService.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/CooperationService.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
+++ b/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -51,7 +51,6 @@ import se.skltp.cooperation.repository.ServiceProductionRepository;
 /**
  * Load database with test data
  *
- * @author Peter Merikan
  */
 
 @Service

--- a/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
+++ b/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
+++ b/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -25,8 +25,8 @@ public class InstalledContractCriteria {
 
 	Long connectionPointId;
 	Long serviceContractId;
-	Long serviceDomainId;	
-	
+	Long serviceDomainId;
+
 	public InstalledContractCriteria(Long connectionPointId, Long serviceContractId, Long serviceDomainId) {
 		this.connectionPointId = connectionPointId;
 		this.serviceContractId = serviceContractId;

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -28,13 +28,13 @@ public class LogicalAddressCriteria {
 	Long serviceContractId;
 	Long connectionPointId;
 	Long serviceProducerId;
-	
+
 	public boolean isEmpty() {
 
 		return logicalAdress == null && serviceConsumerId == null && serviceContractId == null
 			&& connectionPointId == null && serviceProducerId == null;
 	}
-	
+
 	public LogicalAddressCriteria(String logicalAdress, Long serviceConsumerId,
 			Long serviceContractId, Long connectionPointId, Long serviceProducerId) {
 		this.logicalAdress = logicalAdress;

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -24,7 +24,6 @@ package se.skltp.cooperation.service;
  * A criteria object to be used when fetching
  * {@link se.skltp.cooperation.domain.ServiceConsumer}
  *
- * @author Peter Merikan
  */
 public class ServiceConsumerCriteria {
 	private Long connectionPointId;
@@ -79,5 +78,5 @@ public class ServiceConsumerCriteria {
 	public void setServiceProducerId(Long serviceProducerId) {
 		this.serviceProducerId = serviceProducerId;
 	}
-	
+
 }

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -25,7 +25,6 @@ import se.skltp.cooperation.domain.ServiceConsumer;
 import java.util.List;
 
 /**
- * @author Peter Merikan
  */
 public interface ServiceConsumerService {
 	List<ServiceConsumer> findAll();

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -28,8 +28,8 @@ public class ServiceContractCriteria {
 	Long logicalAddressId;
 	Long connectionPointId;
 	Long serviceProducerId;
-	Long serviceDomainId;	
-	
+	Long serviceDomainId;
+
 	public ServiceContractCriteria(String namespace, Long serviceConsumerId,
 			Long logicalAddressId, Long connectionPointId, Long serviceProducerId, Long serviceDomainId) {
 		this.namespace = namespace;

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -29,7 +29,7 @@ public class ServiceDomainCriteria {
 
 		return namespace == null ;
 	}
-	
+
 	public ServiceDomainCriteria(String namespace) {
 		this.namespace = namespace;
 	}

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -31,7 +31,7 @@ public interface ServiceDomainService {
 
 	/**
 	 * Find all ServiceDomains
-	 * 
+	 *
 	 * @param criteria
 	 *
 	 * @return List A list of {@link ServiceDomain} objects.

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -31,7 +31,7 @@ public interface ServiceProducerService {
 
 	/**
 	 * Find all ServiceProducers
-	 * @param criteria 
+	 * @param criteria
 	 *
 	 * @return List A list of {@link ServiceProducer} objects.
 	 */

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -109,6 +109,6 @@ public class ServiceProductionCriteria {
 
 	public void setDomainId(Long domainId) {
 		this.domainId = domainId;
-	}	
-	
+	}
+
 }

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -25,7 +25,6 @@ import java.util.List;
 import se.skltp.cooperation.domain.ServiceProduction;
 
 /**
- * @author Peter Merikan
  */
 public interface ServiceProductionService {
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -33,12 +33,11 @@ import se.skltp.cooperation.repository.ConnectionPointRepository;
 import se.skltp.cooperation.service.ConnectionPointCriteria;
 import se.skltp.cooperation.service.ConnectionPointService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
- * @author Peter Merikan
  */
 @Service
 @Transactional(readOnly = true)
@@ -58,7 +57,7 @@ public class ConnectionPointServiceImpl implements ConnectionPointService {
 			return connectionPointRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(connectionPointRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(connectionPointRepository.findAll(predicate));
 		}
 
 	}

--- a/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,12 +32,11 @@ import se.skltp.cooperation.repository.CooperationRepository;
 import se.skltp.cooperation.service.CooperationCriteria;
 import se.skltp.cooperation.service.CooperationService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
- * @author Peter Merikan
  */
 @Service
 @Transactional(readOnly = true)
@@ -57,7 +56,7 @@ public class CooperationServiceImpl implements CooperationService {
 			return cooperationRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(cooperationRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(cooperationRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,9 +32,9 @@ import se.skltp.cooperation.repository.InstalledContractRepository;
 import se.skltp.cooperation.service.InstalledContractCriteria;
 import se.skltp.cooperation.service.InstalledContractService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -56,7 +56,7 @@ public class InstalledContractServiceImpl implements InstalledContractService {
 			return installedContractRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(installedContractRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(installedContractRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -31,9 +31,9 @@ import se.skltp.cooperation.domain.QLogicalAddress;
 import se.skltp.cooperation.repository.LogicalAddressRepository;
 import se.skltp.cooperation.service.LogicalAddressCriteria;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -55,7 +55,7 @@ public class LogicalAdressServiceImpl implements se.skltp.cooperation.service.Lo
 			return logicalAddressRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(logicalAddressRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(logicalAddressRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImpl.java
@@ -16,13 +16,12 @@ import se.skltp.cooperation.repository.ServiceConsumerRepository;
 import se.skltp.cooperation.service.ServiceConsumerCriteria;
 import se.skltp.cooperation.service.ServiceConsumerService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.JPAExpressions;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
- * @author Peter Merikan
  */
 @Service
 @Transactional(readOnly = true)
@@ -51,7 +50,7 @@ public class ServiceConsumerServiceImpl implements ServiceConsumerService {
 			return findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(serviceConsumerRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(serviceConsumerRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -31,9 +31,9 @@ import se.skltp.cooperation.domain.ServiceContract;
 import se.skltp.cooperation.repository.ServiceContractRepository;
 import se.skltp.cooperation.service.ServiceContractCriteria;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -55,7 +55,7 @@ public class ServiceContractServiceImpl implements se.skltp.cooperation.service.
 			return serviceContractRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(serviceContractRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(serviceContractRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,9 +32,9 @@ import se.skltp.cooperation.repository.ServiceDomainRepository;
 import se.skltp.cooperation.service.ServiceDomainCriteria;
 import se.skltp.cooperation.service.ServiceDomainService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -57,7 +57,7 @@ public class ServiceDomainServiceImpl implements ServiceDomainService {
 			return serviceDomainRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(serviceDomainRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(serviceDomainRepository.findAll(predicate));
 		}
 
 	}

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -32,10 +32,10 @@ import se.skltp.cooperation.domain.ServiceProducer;
 import se.skltp.cooperation.repository.ServiceProducerRepository;
 import se.skltp.cooperation.service.ServiceProducerCriteria;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.JPAExpressions;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -58,7 +58,7 @@ public class ServiceProducerServiceImpl implements
 			return serviceProducerRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(serviceProducerRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(serviceProducerRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -34,9 +34,9 @@ import se.skltp.cooperation.repository.ServiceProductionRepository;
 import se.skltp.cooperation.service.ServiceProductionCriteria;
 import se.skltp.cooperation.service.ServiceProductionService;
 
-import com.google.common.collect.Lists;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import se.skltp.cooperation.util.ControllerUtils;
 
 /**
  * @author Jan Vasternas
@@ -61,7 +61,7 @@ public class ServiceProductionServiceImpl implements ServiceProductionService {
 			return serviceProductionRepository.findAll();
 		} else {
 			Predicate predicate = buildPredicate(criteria);
-			return Lists.newArrayList(serviceProductionRepository.findAll(predicate));
+			return ControllerUtils.iterableToArrayList(serviceProductionRepository.findAll(predicate));
 		}
 	}
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/main/java/se/skltp/cooperation/util/ControllerUtils.java
+++ b/src/main/java/se/skltp/cooperation/util/ControllerUtils.java
@@ -1,0 +1,28 @@
+package se.skltp.cooperation.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class ControllerUtils {
+
+	private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+	private ControllerUtils() {	}
+
+	public static List<String> splitCommaSeparated(String input) {
+		if (input == null || input.isBlank()) {
+			return List.of();
+		}
+
+		return COMMA_PATTERN.splitAsStream(input)
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.toList();
+	}
+
+	public static <T> List<T> iterableToArrayList(Iterable<T> iterable) {
+		List<T> result = new ArrayList<>();
+		iterable.forEach(result::add);
+		return result;
+	}
+}

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:h2:mem:cooperation;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  sql:
+    init:
+      platform: h2
+  jpa:
+    open-in-view: true
+  h2:
+    console.enabled: true
+
+logging:
+  config: classpath:log4j2-dev.xml

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  sql:
+    init:
+      platform: mysql
+  datasource:
+    url: ${COOPERATION_DB_URL}
+    username: ${COOPERATION_DB_USER}
+    password: ${COOPERATION_DB_PASSWORD}
+    driverClassName: com.mysql.cj.jdbc.Driver
+    testOnBorrow: true
+    validationQuery: SELECT 1
+  jpa:
+    open-in-view: true

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,5 +1,10 @@
-spring.profiles.active: dev
 
+spring:
+  main:
+    banner-mode: off
+  profiles:
+    active: dev
+    
 server:
   port: 8080
   error:
@@ -28,44 +33,3 @@ settings:
   allowApi_createAnyUsers: true
   allowApi_createSuperAdmins: false
   allowApi_downloadSampleUserFile: true
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: dev
-  datasource:
-    url: jdbc:h2:mem:cooperation;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driverClassName: org.h2.Driver
-    username: sa
-    password:
-  sql:
-    init:
-      platform: h2
-  jpa:
-    open-in-view: true
-  h2:
-    console.enabled: true
-
-logging:
-  config: classpath:log4j2-dev.xml
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: prod
-  sql:
-    init:
-      platform: mysql
-  datasource:
-    url: ${COOPERATION_DB_URL}
-    username: ${COOPERATION_DB_USER}
-    password: ${COOPERATION_DB_PASSWORD}
-    driverClassName: com.mysql.cj.jdbc.Driver
-    testOnBorrow: true
-    validationQuery: SELECT 1
-  jpa:
-    open-in-view: true

--- a/src/main/resources/static/doc/index.html
+++ b/src/main/resources/static/doc/index.html
@@ -1,7 +1,7 @@
 <!--
 
-    Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
-                    <http://cehis.se/>
+    Copyright (c) 2026 Inera.
+
 
     This file is part of SKLTP.
 

--- a/src/main/resources/static/doc/index_v2.html
+++ b/src/main/resources/static/doc/index_v2.html
@@ -1,7 +1,7 @@
 <!--
 
-    Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
-                    <http://cehis.se/>
+    Copyright (c) 2026 Inera.
+
 
     This file is part of SKLTP.
 

--- a/src/test/java/se/skltp/cooperation/ApplicationTest.java
+++ b/src/test/java/se/skltp/cooperation/ApplicationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation;

--- a/src/test/java/se/skltp/cooperation/ApplicationTest.java
+++ b/src/test/java/se/skltp/cooperation/ApplicationTest.java
@@ -1,21 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation;
 

--- a/src/test/java/se/skltp/cooperation/ApplicationTest.java
+++ b/src/test/java/se/skltp/cooperation/ApplicationTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
  *
  * This file is part of SKLTP.
  *
@@ -20,19 +19,10 @@
  */
 package se.skltp.cooperation;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-
-/**
- * Test class for Application
- *
- * @author Peter Merikan
- */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class ApplicationTest {

--- a/src/test/java/se/skltp/cooperation/api/TestUtil.java
+++ b/src/test/java/se/skltp/cooperation/api/TestUtil.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api;

--- a/src/test/java/se/skltp/cooperation/api/TestUtil.java
+++ b/src/test/java/se/skltp/cooperation/api/TestUtil.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * Utility class for testing REST controllers.
  *
- * @author Peter Merikan
  */
 @Service
 public class TestUtil {

--- a/src/test/java/se/skltp/cooperation/api/TestUtil.java
+++ b/src/test/java/se/skltp/cooperation/api/TestUtil.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api;
 

--- a/src/test/java/se/skltp/cooperation/api/Version1GoneTest.java
+++ b/src/test/java/se/skltp/cooperation/api/Version1GoneTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import se.skltp.cooperation.Application;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = Application.class)
 @ContextConfiguration(classes = SecurityConfig.class)
@@ -26,8 +26,8 @@ public class Version1GoneTest {
 
 	@Test
 	public void getAnyVersion1Resource_shouldBeToldIsGone() throws Exception {
-    	assertEquals("Response must be of Type 'ResponseEntity'", "ResponseEntity", version1Gone.respondWithGone().getClass().getSimpleName());
+    	assertEquals("ResponseEntity", version1Gone.respondWithGone().getClass().getSimpleName(),"Response must be of Type 'ResponseEntity'");
 		ResponseEntity<String> result = version1Gone.respondWithGone();
-    	assertSame("Response must be of type HTTP 410 GONE.", HttpStatus.GONE, result.getStatusCode());
+    	assertSame(HttpStatus.GONE, result.getStatusCode(), "Response must be of type HTTP 410 GONE.");
 	}
 }

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -40,9 +40,14 @@ import java.util.Arrays;
 
 import org.apache.catalina.security.SecurityConfig;
 import org.modelmapper.ModelMapper;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+//import org.joda.time.DateTimeZone;
+//import org.joda.time.format.DateTimeFormat;
+//import org.joda.time.format.DateTimeFormatter;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +73,6 @@ import se.skltp.cooperation.api.v2.dto.ConnectionPointDTO;
 /**
  * Test class for the ConnectionPointController REST controller.
  *
- * @author Peter Merikan
  * @see ConnectionPointController
  */
 
@@ -79,7 +83,16 @@ import se.skltp.cooperation.api.v2.dto.ConnectionPointDTO;
 @WebAppConfiguration
 public class ConnectionPointControllerTest {
 
-	private static DateTimeFormatter isoDateFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZone(DateTimeZone.forID("CET"));
+	private static final DateTimeFormatter ISO_DATE_FORMATTER =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")
+			.withZone(ZoneId.of("CET"));
+
+	private static Date parseDate(String value) {
+		return Date.from(ZonedDateTime.parse(value, ISO_DATE_FORMATTER).toInstant());
+	}
+	private static String formatDate(Date value) {
+		return ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(value.getTime()));
+	}
 
 	ConnectionPoint cp1;
 	ConnectionPoint cp2;
@@ -114,12 +127,12 @@ public class ConnectionPointControllerTest {
 		dto1.setId(1L);
 		dto1.setPlatform("dto1.platform");
 		dto1.setEnvironment("dto1.environment");
-		dto1.setSnapshotTime(isoDateFormatter.parseDateTime("2015-10-13T10:14:25+0200").toDate());
+		dto1.setSnapshotTime(Date.from(ZonedDateTime.parse("2015-10-13T10:14:25+0200", ISO_DATE_FORMATTER).toInstant()));
 		dto2 = new ConnectionPointDTO();
 		dto2.setId(2L);
 		dto2.setPlatform("dto2.platform");
 		dto2.setEnvironment("dto2.environment");
-		dto2.setSnapshotTime(isoDateFormatter.parseDateTime("2015-10-13T10:15:12+0200").toDate());
+		dto2.setSnapshotTime(Date.from(ZonedDateTime.parse("2015-10-13T10:15:12+0200", ISO_DATE_FORMATTER).toInstant()));
 
 	}
 
@@ -136,11 +149,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.[0].id").value(is(dto1.getId().intValue())))
 			.andExpect(jsonPath("$.[0].platform").value(is(dto1.getPlatform())))
 			.andExpect(jsonPath("$.[0].environment").value(is(dto1.getEnvironment())))
-			.andExpect(jsonPath("$.[0].snapshotTime", is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))))
+			.andExpect(jsonPath("$.[0].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
 			.andExpect(jsonPath("$.[1].id").value(is(dto2.getId().intValue())))
 			.andExpect(jsonPath("$.[1].platform").value(is(dto2.getPlatform())))
 			.andExpect(jsonPath("$.[1].environment").value(is(dto2.getEnvironment())))
-			.andExpect(jsonPath("$.[1].snapshotTime", is(isoDateFormatter.print(dto2.getSnapshotTime().getTime()))))
+			.andExpect(jsonPath("$.[1].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))))
 		;
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
@@ -161,11 +174,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.[0].id").value(is(dto1.getId().intValue())))
 			.andExpect(jsonPath("$.[0].platform").value(is(dto1.getPlatform())))
 			.andExpect(jsonPath("$.[0].environment").value(is(dto1.getEnvironment())))
-			.andExpect(jsonPath("$.[0].snapshotTime", is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))))
+			.andExpect(jsonPath("$.[0].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
 			.andExpect(jsonPath("$.[1].id").value(is(dto2.getId().intValue())))
 			.andExpect(jsonPath("$.[1].platform").value(is(dto2.getPlatform())))
 			.andExpect(jsonPath("$.[1].environment").value(is(dto2.getEnvironment())))
-			.andExpect(jsonPath("$.[1].snapshotTime", is(isoDateFormatter.print(dto2.getSnapshotTime().getTime()))))
+			.andExpect(jsonPath("$.[1].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))))
 		;
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
@@ -186,11 +199,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))))
+			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/id").string(is(dto2.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/platform").string(is(dto2.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/environment").string(is(dto2.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(isoDateFormatter.print(dto2.getSnapshotTime().getTime()))));
+			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))));
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
 		verifyNoMoreInteractions(connectionPointServiceMock);
@@ -210,11 +223,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))))
+			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/id").string(is(dto2.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/platform").string(is(dto2.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/environment").string(is(dto2.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(isoDateFormatter.print(dto2.getSnapshotTime().getTime()))));
+			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))));
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
 		verifyNoMoreInteractions(connectionPointServiceMock);
@@ -262,7 +275,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.id").value(dto1.getId().intValue()))
 			.andExpect(jsonPath("$.platform").value(dto1.getPlatform()))
 			.andExpect(jsonPath("$.environment").value(dto1.getEnvironment()))
-			.andExpect(jsonPath("$.snapshotTime", is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))));
+			.andExpect(jsonPath("$.snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
 	}
 
 	@Test
@@ -278,7 +291,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
 	}
 
 	@Test
@@ -294,7 +307,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.id").value(dto1.getId().intValue()))
 			.andExpect(jsonPath("$.platform").value(dto1.getPlatform()))
 			.andExpect(jsonPath("$.environment").value(dto1.getEnvironment()))
-			.andExpect(jsonPath("$.snapshotTime", is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))));
+			.andExpect(jsonPath("$.snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
 	}
 
 	@Test
@@ -310,7 +323,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
 	}
 
 	@Test
@@ -325,7 +338,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(isoDateFormatter.print(dto1.getSnapshotTime().getTime()))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
 	}
 
 	@Test

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
@@ -1,28 +1,14 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -112,7 +98,7 @@ public class ConnectionPointControllerTest {
     private WebApplicationContext context;
 
 	@BeforeEach
-	public void setUpTestData() throws Exception {
+	public void setUpTestData() {
 
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilter(((request, response, chain) -> {
             response.setCharacterEncoding("UTF-8");
@@ -127,12 +113,12 @@ public class ConnectionPointControllerTest {
 		dto1.setId(1L);
 		dto1.setPlatform("dto1.platform");
 		dto1.setEnvironment("dto1.environment");
-		dto1.setSnapshotTime(Date.from(ZonedDateTime.parse("2015-10-13T10:14:25+0200", ISO_DATE_FORMATTER).toInstant()));
+		dto1.setSnapshotTime(parseDate("2015-10-13T10:14:25+0200"));
 		dto2 = new ConnectionPointDTO();
 		dto2.setId(2L);
 		dto2.setPlatform("dto2.platform");
 		dto2.setEnvironment("dto2.environment");
-		dto2.setSnapshotTime(Date.from(ZonedDateTime.parse("2015-10-13T10:15:12+0200", ISO_DATE_FORMATTER).toInstant()));
+		dto2.setSnapshotTime(parseDate("2015-10-13T10:15:12+0200"));
 
 	}
 
@@ -149,11 +135,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.[0].id").value(is(dto1.getId().intValue())))
 			.andExpect(jsonPath("$.[0].platform").value(is(dto1.getPlatform())))
 			.andExpect(jsonPath("$.[0].environment").value(is(dto1.getEnvironment())))
-			.andExpect(jsonPath("$.[0].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
+			.andExpect(jsonPath("$.[0].snapshotTime", is(formatDate(dto1.getSnapshotTime()))))
 			.andExpect(jsonPath("$.[1].id").value(is(dto2.getId().intValue())))
 			.andExpect(jsonPath("$.[1].platform").value(is(dto2.getPlatform())))
 			.andExpect(jsonPath("$.[1].environment").value(is(dto2.getEnvironment())))
-			.andExpect(jsonPath("$.[1].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))))
+			.andExpect(jsonPath("$.[1].snapshotTime", is(formatDate(dto2.getSnapshotTime()))))
 		;
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
@@ -174,11 +160,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.[0].id").value(is(dto1.getId().intValue())))
 			.andExpect(jsonPath("$.[0].platform").value(is(dto1.getPlatform())))
 			.andExpect(jsonPath("$.[0].environment").value(is(dto1.getEnvironment())))
-			.andExpect(jsonPath("$.[0].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
+			.andExpect(jsonPath("$.[0].snapshotTime", is(formatDate(dto1.getSnapshotTime()))))
 			.andExpect(jsonPath("$.[1].id").value(is(dto2.getId().intValue())))
 			.andExpect(jsonPath("$.[1].platform").value(is(dto2.getPlatform())))
 			.andExpect(jsonPath("$.[1].environment").value(is(dto2.getEnvironment())))
-			.andExpect(jsonPath("$.[1].snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))))
+			.andExpect(jsonPath("$.[1].snapshotTime", is(formatDate(dto2.getSnapshotTime()))))
 		;
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
@@ -199,11 +185,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
+			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(formatDate(dto1.getSnapshotTime()))))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/id").string(is(dto2.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/platform").string(is(dto2.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/environment").string(is(dto2.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))));
+			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(formatDate(dto2.getSnapshotTime()))));
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
 		verifyNoMoreInteractions(connectionPointServiceMock);
@@ -223,11 +209,11 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[1]/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))))
+			.andExpect(xpath("/connectionPoints/connectionPoint[1]/snapshotTime").string(is(formatDate(dto1.getSnapshotTime()))))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/id").string(is(dto2.getId().toString())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/platform").string(is(dto2.getPlatform())))
 			.andExpect(xpath("/connectionPoints/connectionPoint[2]/environment").string(is(dto2.getEnvironment())))
-			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto2.getSnapshotTime().getTime())))));
+			.andExpect(xpath("/connectionPoints/connectionPoint[2]/snapshotTime").string(is(formatDate(dto2.getSnapshotTime()))));
 
 		verify(connectionPointServiceMock, times(1)).findAll(any(ConnectionPointCriteria.class));
 		verifyNoMoreInteractions(connectionPointServiceMock);
@@ -238,7 +224,7 @@ public class ConnectionPointControllerTest {
 	public void getAllAcceptJson_shouldReturnEmptyList() throws Exception {
 
 		ConnectionPointCriteria criteria = new ConnectionPointCriteria(null, null, null, null, null, null);
-		when(connectionPointServiceMock.findAll(criteria)).thenReturn(new ArrayList<ConnectionPoint>());
+		when(connectionPointServiceMock.findAll(criteria)).thenReturn(new ArrayList<>());
 
 		mockMvc.perform(get("/api/v2/connectionPoints").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -251,7 +237,7 @@ public class ConnectionPointControllerTest {
 	public void getAllAcceptXml_shouldReturnEmptyList() throws Exception {
 
 		ConnectionPointCriteria criteria = new ConnectionPointCriteria(null, null, null, null, null, null);
-		when(connectionPointServiceMock.findAll(criteria)).thenReturn(new ArrayList<ConnectionPoint>());
+		when(connectionPointServiceMock.findAll(criteria)).thenReturn(new ArrayList<>());
 
 		mockMvc.perform(get("/api/v2/connectionPoints").accept(MediaType.APPLICATION_XML_VALUE))
 			.andExpect(status().isOk())
@@ -275,7 +261,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.id").value(dto1.getId().intValue()))
 			.andExpect(jsonPath("$.platform").value(dto1.getPlatform()))
 			.andExpect(jsonPath("$.environment").value(dto1.getEnvironment()))
-			.andExpect(jsonPath("$.snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
+			.andExpect(jsonPath("$.snapshotTime", is(formatDate(dto1.getSnapshotTime()))));
 	}
 
 	@Test
@@ -291,7 +277,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(formatDate(dto1.getSnapshotTime()))));
 	}
 
 	@Test
@@ -307,7 +293,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(jsonPath("$.id").value(dto1.getId().intValue()))
 			.andExpect(jsonPath("$.platform").value(dto1.getPlatform()))
 			.andExpect(jsonPath("$.environment").value(dto1.getEnvironment()))
-			.andExpect(jsonPath("$.snapshotTime", is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
+			.andExpect(jsonPath("$.snapshotTime", is(formatDate(dto1.getSnapshotTime()))));
 	}
 
 	@Test
@@ -323,7 +309,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(formatDate(dto1.getSnapshotTime()))));
 	}
 
 	@Test
@@ -338,7 +324,7 @@ public class ConnectionPointControllerTest {
 			.andExpect(xpath("/connectionPoint/id").string(is(dto1.getId().toString())))
 			.andExpect(xpath("/connectionPoint/platform").string(is(dto1.getPlatform())))
 			.andExpect(xpath("/connectionPoint/environment").string(is(dto1.getEnvironment())))
-			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(ISO_DATE_FORMATTER.format(Instant.ofEpochMilli(dto1.getSnapshotTime().getTime())))));
+			.andExpect(xpath("/connectionPoint/snapshotTime").string(is(formatDate(dto1.getSnapshotTime()))));
 	}
 
 	@Test
@@ -348,7 +334,7 @@ public class ConnectionPointControllerTest {
 		mockMvc.perform(get("/api/v2/connectionPoints/{id}", Long.MAX_VALUE)
 	    	      .contentType(MediaType.APPLICATION_JSON))
 	    	      .andExpect(status().isNotFound())
-	    	      .andExpect(result -> assertTrue(result.getResolvedException() instanceof ResourceNotFoundException)
+	    	      .andExpect(result -> assertInstanceOf(ResourceNotFoundException.class, result.getResolvedException())
 	    	      );
 
 	}

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -49,7 +49,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -59,7 +59,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Tests for {@link CooperationController}
  *
- * @author Peter Merikan
  */
 @SpringBootTest(classes = Application.class)
 @ContextConfiguration(classes = SecurityConfig.class)

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -51,7 +51,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -61,7 +61,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Test class for the ServiceConsumerController REST controller.
  *
- * @author Peter Merikan
  * @see ServiceConsumerController
  */
 @SpringBootTest(classes = Application.class)

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;

--- a/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,16 +20,17 @@
  */
 package se.skltp.cooperation.api.v2.format;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HTTPObfuscatorTest {
 
 	private HTTPObfuscator uut;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		uut = new HTTPObfuscatorImpl();
 

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
@@ -1,7 +1,5 @@
 package se.skltp.cooperation.basicauthmodule;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,8 +19,6 @@ class ServiceUserManagementTest {
 
   @Autowired
   ServiceUserManagement mgmt;
-
-  private static final Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
 
   @Test
   void whenAddingAndDeletingUser_worksAsExpected() {
@@ -59,14 +55,17 @@ class ServiceUserManagementTest {
     assertEquals(dummies.getUsers().size(), 3);
   }
 
-  @Test
-  void whenSerializingAndDeserializingUser_GsonPluginWorksAsExpected() {
-    ServiceUser user = createQuickDummyUser1_Caesar();
-    String userSerialized = gson.toJson(user); // Serialize.
-    ServiceUser userDeserialized = gson.fromJson(userSerialized, ServiceUser.class); // Deserialize.
-
-    assertEquals(user, userDeserialized);
-  }
+//  @Test
+//  void whenSerializingAndDeserializingUser_GsonPluginWorksAsExpected() {
+//    ServiceUser user = createQuickDummyUser1_Caesar();
+////    String userSerialized = gson.toJson(user); // Serialize.
+////    ServiceUser userDeserialized = gson.fromJson(userSerialized, ServiceUser.class); // Deserialize.
+//
+//	String userSerialized = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(user);
+//	ServiceUser userDeserialized = objectMapper.readValue(userSerialized, ServiceUser.class);
+//
+//    assertEquals(user, userDeserialized);
+//  }
 
   public static ServiceUser createQuickDummyUser1_Caesar() {
     ServiceUser user = new ServiceUser(

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
@@ -50,36 +50,8 @@ class ServiceUserManagementTest {
   }
 
   @Test
-  void whenCreatingDummmyUsers_AddAndRetrieveUsers_usersAreAsExpected() {
+  void whenCreatingDummyUsers_AddAndRetrieveUsers_usersAreAsExpected() {
     ServiceUserListWrapper dummies = mgmt.getDummyUserList();
-    assertEquals(dummies.getUsers().size(), 3);
-  }
-
-//  @Test
-//  void whenSerializingAndDeserializingUser_GsonPluginWorksAsExpected() {
-//    ServiceUser user = createQuickDummyUser1_Caesar();
-////    String userSerialized = gson.toJson(user); // Serialize.
-////    ServiceUser userDeserialized = gson.fromJson(userSerialized, ServiceUser.class); // Deserialize.
-//
-//	String userSerialized = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(user);
-//	ServiceUser userDeserialized = objectMapper.readValue(userSerialized, ServiceUser.class);
-//
-//    assertEquals(user, userDeserialized);
-//  }
-
-  public static ServiceUser createQuickDummyUser1_Caesar() {
-    ServiceUser user = new ServiceUser(
-        "Caesar",
-        MyUserDetailsService.generateHashedPassword("Qwert123"),
-        // For specimen password "qwerty"...:
-        // Stored as BCrypt-encode at strength 10 as "$2y$10$Ffs4rDCIok.I3uuQ8IIMxufD5FoTvhxymukqEBElHwRxEvaLy8dRO",
-        // Sent over web, encoded as BASE64 it is: "SGVucmlrOnF3ZXJ0eQ=="
-        "Caesar Julius",
-        "NMT",
-        "cc@a.aa",
-        "073-1234567",
-        Arrays.asList(Settings.REG_USER_ROLE, Settings.REG_ADMIN_ROLE)
-    );
-    return user;
+    assertEquals(3, dummies.getUsers().size());
   }
 }

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -23,7 +23,6 @@ package se.skltp.cooperation.service;
 /**
  * A builder object for CooperationCriteria
  *
- * @author Peter Merikan
  */
 public class CooperationCriteriaBuilder {
 

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,20 +20,17 @@
  */
 package se.skltp.cooperation.service;
 
-import org.junit.Before;
-import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
 
-/**
- * @author Peter Merikan
- */
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class CooperationCriteriaTest {
 
 	private CooperationCriteria uut;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		uut = new CooperationCriteria();
 

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;

--- a/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,20 +20,19 @@
  */
 package se.skltp.cooperation.service;
 
-import org.junit.Before;
-import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Peter Merikan
  */
 public class ServiceConsumerCriteriaTest {
 
 	private ServiceConsumerCriteria uut;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		uut = new ServiceConsumerCriteria();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Peter Merikan
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class)

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -49,7 +45,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class CooperationServiceImplIntegrationTest {
@@ -76,7 +71,7 @@ public class CooperationServiceImplIntegrationTest {
 	ServiceDomain serviceDomain1;
 	ServiceDomain serviceDomain2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -101,7 +96,7 @@ public class CooperationServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress1, serviceProducer1, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -50,7 +50,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Peter Merikan
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class)

--- a/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -50,7 +46,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class InstalledContractServiceImplIntegrationTest {
@@ -82,7 +77,7 @@ public class InstalledContractServiceImplIntegrationTest {
 
 	ServiceDomain serviceDomain;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -112,7 +107,7 @@ public class InstalledContractServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress2, serviceProducer2, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -48,7 +44,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class LogicalAdressServiceImplIntegrationTest {
@@ -76,7 +71,7 @@ public class LogicalAdressServiceImplIntegrationTest {
 	ServiceProducer serviceProducer1;
 	ServiceProducer serviceProducer2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -103,7 +98,7 @@ public class LogicalAdressServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress2, serviceProducer2, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -48,7 +44,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class ServiceConsumerServiceImplIntegrationTest {
@@ -77,7 +72,7 @@ public class ServiceConsumerServiceImplIntegrationTest {
 	ServiceProduction serviceProduction2;
 	ServiceProducer serviceProducer2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -104,7 +99,7 @@ public class ServiceConsumerServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress3, serviceProducer2, serviceContract2);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -50,7 +50,6 @@ import com.querydsl.core.types.Predicate;
 /**
  * Tests for {@link ServiceConsumerServiceImpl}
  *
- * @author Peter Merikan
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class)

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -49,7 +45,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class ServiceContractServiceImplIntegrationTest {
@@ -79,7 +74,7 @@ public class ServiceContractServiceImplIntegrationTest {
 
 	ServiceDomain serviceDomain;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -107,7 +102,7 @@ public class ServiceContractServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress2, serviceProducer2, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -48,7 +44,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class ServiceProducerServiceImplIntegrationTest {
@@ -76,7 +71,7 @@ public class ServiceProducerServiceImplIntegrationTest {
 	ServiceProducer serviceProducer1;
 	ServiceProducer serviceProducer2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -103,7 +98,7 @@ public class ServiceProducerServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress2, serviceProducer2, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
@@ -1,22 +1,8 @@
 /**
- * Copyright (c) 2026 Inera.
- *
- *
- * This file is part of SKLTP.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Copyright (c) 2015-2026 Inera.
+ * This file is part of the SKLTP project and software kit.
+ * This library is free software under the GNU Lesser General Public License v2.1.
+ * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2014 Center for eHalsa i samverkan (CeHis).
- * 								<http://cehis.se/>
+ * Copyright (c) 2026 Inera.
+ *
  *
  * This file is part of SKLTP.
  *
@@ -20,17 +20,13 @@
  */
 package se.skltp.cooperation.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import se.skltp.cooperation.Application;
@@ -48,7 +44,6 @@ import se.skltp.cooperation.api.TestUtil;
 /**
  * @author Jan Västernäs
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class ServiceProductionServiceImplIntegrationTest {
@@ -76,7 +71,7 @@ public class ServiceProductionServiceImplIntegrationTest {
 	ServiceDomain serviceDomain1;
 	ServiceDomain serviceDomain2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		connectionPoint1 = util.createConnectionPoint("NTJP", "TEST");
 		connectionPoint2 = util.createConnectionPoint("NTJP", "PROD");
@@ -101,7 +96,7 @@ public class ServiceProductionServiceImplIntegrationTest {
 				connectionPoint1, logicalAddress2, serviceProducer2, serviceContract1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		util.deleteAll();
 	}

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 /**
  * Copyright (c) 2015-2026 Inera.
- * This file is part of the SKLTP project and software kit.
- * This library is free software under the GNU Lesser General Public License v2.1.
+ * * This library is free software under the GNU Lesser General Public License v2.1.
  * Refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;

--- a/src/test/java/se/skltp/cooperation/util/ControllerUtilsTest.java
+++ b/src/test/java/se/skltp/cooperation/util/ControllerUtilsTest.java
@@ -1,0 +1,75 @@
+package se.skltp.cooperation.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ControllerUtilsTest {
+
+	@Test
+	void splitCommaSeparated_shouldReturnEmptyListForNullInput() {
+		List<String> result = ControllerUtils.splitCommaSeparated(null);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void splitCommaSeparated_shouldReturnEmptyListForBlankInput() {
+		List<String> result = ControllerUtils.splitCommaSeparated("   ");
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void splitCommaSeparated_shouldSplitTrimAndOmitEmptyEntries() {
+		List<String> result = ControllerUtils.splitCommaSeparated(" one, two , , three,  ,four ");
+
+		assertEquals(List.of("one", "two", "three", "four"), result);
+	}
+
+	@Test
+	void splitCommaSeparated_shouldPreserveOrderAndDuplicates() {
+		List<String> result = ControllerUtils.splitCommaSeparated("a, b, a , c");
+
+		assertEquals(List.of("a", "b", "a", "c"), result);
+	}
+
+	@Test
+	void splitCommaSeparated_shouldHandleSingleValue() {
+		List<String> result = ControllerUtils.splitCommaSeparated("value");
+
+		assertEquals(List.of("value"), result);
+	}
+
+	@Test
+	void iterableToArrayList_shouldCopyElementsFromIterable() {
+		Iterable<String> iterable = List.of("one", "two", "three");
+
+		List<String> result = ControllerUtils.iterableToArrayList(iterable);
+
+		assertEquals(List.of("one", "two", "three"), result);
+	}
+
+	@Test
+	void iterableToArrayList_shouldReturnEmptyListForEmptyIterable() {
+		Iterable<String> iterable = List.of();
+
+		List<String> result = ControllerUtils.iterableToArrayList(iterable);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void iterableToArrayList_shouldReturnMutableArrayList() {
+		Iterable<String> iterable = List.of("one", "two");
+
+		List<String> result = ControllerUtils.iterableToArrayList(iterable);
+
+		assertInstanceOf(ArrayList.class, result);
+		assertDoesNotThrow(() -> result.add("three"));
+		assertEquals(List.of("one", "two", "three"), result);
+	}
+}


### PR DESCRIPTION
- Upgrade Java 17 --> 21, across app POMs, Jenkins, and Dockerfiles.
- Spring Boot 3.4.1 --> 3.5.11.
- Reworked main POM file.
  - Introduced usage of Spring Boot Dependencies BOM, and thus could remove many manually set versions.
  - Also introduced BOM for OpenFeign QueryDSL.
  - Altered the POM layout to fit Maven's style guides.
- Updated misc dependencies: QueryDSL, Modelmapper, Jacoco, ECS-logging.
- Removed deps: Gson, Joda-time, Guava to reduce 3rd party dependence and complexity.
  - Implemented a few Controller-Utils to replace functionality from these deps.
- Upgraded all tests from Junit 4 Legacy to Junit 5.
- Cleanups: removed all outdated 'cehis' links, fixed copyrights, and similar cleanups.