### PR TITLE
Spring Boot and Mycila License plugin.

### DIFF
--- a/License_TAKAPI.md
+++ b/License_TAKAPI.md
@@ -1,5 +1,5 @@
-## Cooperation
-Also known as _TAK-API_.
+## TAK-API
+Also known as _Cooperation_.
 
 Copyright © 2015–2026. Inera, Sweden.
 https://www.inera.se/

--- a/License_header_template.txt
+++ b/License_header_template.txt
@@ -1,0 +1,5 @@
+Copyright © ${copyrightYears} ${owner}.
+Copyright owner URL: ${owner_url}
+${product} overview page: ${product_webpage}
+This library is free software under the GNU Lesser General Public License v2.1 or later.
+Please refer to the full license files at the project root.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.12</version>
+    <version>3.5.16</version>
     <relativePath/>
   </parent>
 
@@ -52,13 +52,13 @@
 
   <properties>
 		<java.version>21</java.version>
-		<spring-boot.version>3.5.12</spring-boot.version> <!-- From Mar 2026 -->
+		<spring-boot.version>3.5.16</spring-boot.version> <!-- From Jun 2026 -->
 
-    <jacoco.plugin.version>0.8.14</jacoco.plugin.version> <!-- From Oct 2025 -->
+    <jacoco.plugin.version>0.8.15</jacoco.plugin.version> <!-- From Jun 2026 -->
     <modelmapper.version>3.2.6</modelmapper.version> <!-- From Nov 2025 -->
 		<openfeign-querydsl.version>6.12</openfeign-querydsl.version> <!-- From Jun 2025 -->
 
-    <ecs-logging-java.version>1.7.0</ecs-logging-java.version> <!-- From Apr 2025 -->
+    <ecs-logging-java.version>1.8.0</ecs-logging-java.version> <!-- From Apr 2026 -->
 
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -213,53 +213,83 @@
 
   <build>
     <finalName>cooperation-${project.version}</finalName>
+
     <pluginManagement>
       <plugins>
-        <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
-          <configuration>
-            <autoVersionSubmodules>true</autoVersionSubmodules>
-            <tagNameFormat>v@{project.version}</tagNameFormat>
-            <localCheckout>true</localCheckout>
-            <arguments>-Dmaven.javadoc.skip=true</arguments>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>com.mycila.maven-license-plugin</groupId>
-          <artifactId>maven-license-plugin</artifactId>
-          <version>1.10.b1</version>
-          <configuration>
-            <properties>
-              <year>2014-2026</year>
-              <copyright>Inera.
-								&lt;https://inera.se/></copyright>
-              <product>SKLTP</product>
-            </properties>
-            <strictCheck>true</strictCheck>
-            <basedir>${basedir}</basedir>
-            <header>header.txt</header>
-            <encoding>UTF-8</encoding>
-            <includes>
-              <include>src/main/**</include>
-              <include>src/test/**</include>
-            </includes>
-            <excludes>
-              <exclude>**/*.xsd</exclude>
-              <exclude>**/*.wsdl</exclude>
-              <exclude>**/*.xml</exclude>
-              <exclude>**/*.dtd</exclude>
-            </excludes>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <mapping>
-              <tag>DYNASCRIPT_STYLE</tag>
-            </mapping>
-            <useDefaultMapping>true</useDefaultMapping>
-          </configuration>
-        </plugin>
+				<plugin>
+					<artifactId>maven-release-plugin</artifactId>
+					<version>3.3.1</version> <!-- DEC 2025. Latest as of APR 2026 -->
+					<configuration>
+						<autoVersionSubmodules>true</autoVersionSubmodules>
+						<tagNameFormat>v@{project.version}</tagNameFormat>
+						<localCheckout>true</localCheckout>
+						<arguments>-Dmaven.javadoc.skip=true</arguments>
+					</configuration>
+				</plugin>
+
+				<!-- User manual for license plugin in IntelliJ IDEA:
+                -Set profile 'license' to true in your IDE and refresh the project.
+                -Go to plugins > license on project-parent level;
+                   and run 'license:check' to control, or 'license:format' to renew file headers.
+                -Disable the 'license' profile and commit your updated headers. -->
+				<plugin>
+					<groupId>com.mycila</groupId>
+					<artifactId>license-maven-plugin</artifactId>
+					<version>5.0.0</version> <!-- MAR 2025. Latest as of APR 2026 -->
+					<configuration>
+						<!-- To fail the build when deprecated configuration is used. -->
+						<prohibitLegacyUse>true</prohibitLegacyUse>
+						<strictCheck>true</strictCheck>
+						<useDefaultMapping>true</useDefaultMapping>
+						<useDefaultExcludes>true</useDefaultExcludes>
+						<basedir>${project.basedir}</basedir>
+						<encoding>UTF-8</encoding>
+
+						<licenseSets>
+							<licenseSet>
+								<header>License_header_template.txt</header>
+
+								<!-- Properties used in the template -->
+								<properties>
+									<copyrightYears>2015-2026</copyrightYears>
+									<inceptionYear>2015</inceptionYear>
+									<product>TAK-API (Cooperation)</product>
+									<owner>Inera</owner>
+									<owner_url>https://www.inera.se/</owner_url>
+									<product_webpage>https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster</product_webpage>
+								</properties>
+
+
+								<!-- File inclusion/exclusion -->
+								<includes>
+									<include>src/**/*.java</include>
+								</includes>
+
+								<excludes>
+									<exclude>target/**</exclude>
+									<exclude>**/target/**</exclude>
+									<exclude>**/*.xsd</exclude>
+									<exclude>**/*.wsdl</exclude>
+									<exclude>**/*.xml</exclude>
+									<exclude>**/*.dtd</exclude>
+									<exclude>**/*.map</exclude>
+									<exclude>**/*.info</exclude>
+									<exclude>**/*.yml</exclude>
+<!--									<exclude>**/src/main/resources/static/doc/**/*.*</exclude>-->
+								</excludes>
+							</licenseSet>
+						</licenseSets>
+					</configuration>
+				</plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+			</plugin>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
 				<!-- VERSION handled by Spring Boot Dependencies BOM -->
@@ -267,6 +297,7 @@
           <release>${java.version}</release>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
@@ -282,27 +313,28 @@
 	<reporting/>
 
   <profiles>
-    <profile>
-      <id>license</id>
-      <activation />
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.mycila.maven-license-plugin</groupId>
-            <artifactId>maven-license-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>check</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+		<profile>
+			<id>license</id>
+			<activation />
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.mycila</groupId>
+						<artifactId>license-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>check-license</id>
+								<phase>compile</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
     <profile>
       <id>test-coverage</id>
       <build>

--- a/src/main/java/se/skltp/cooperation/Application.java
+++ b/src/main/java/se/skltp/cooperation/Application.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation;
 

--- a/src/main/java/se/skltp/cooperation/api/Version1Gone.java
+++ b/src/main/java/se/skltp/cooperation/api/Version1Gone.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api;
 
 import org.springframework.http.HttpStatus;

--- a/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/DefaultExceptionHandler.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/FieldError.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ProblemDetail.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ResourceNotFoundException.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
+++ b/src/main/java/se/skltp/cooperation/api/exception/ValidationError.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.exception;
 

--- a/src/main/java/se/skltp/cooperation/api/info/ControllerLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/ControllerLogger.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import jakarta.servlet.ServletContext;

--- a/src/main/java/se/skltp/cooperation/api/info/ServletMappingLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/ServletMappingLogger.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import jakarta.servlet.ServletContext;

--- a/src/main/java/se/skltp/cooperation/api/info/WebServerInfoLogger.java
+++ b/src/main/java/se/skltp/cooperation/api/info/WebServerInfoLogger.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import org.slf4j.Logger;

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ConnectionPointController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/CooperationController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/InstalledContractController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/LogicalAddressController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceContractController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceDomainController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProducerController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/controller/ServiceProductionController.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ConnectionPointDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/CooperationDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/InstalledContractDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/LogicalAddressDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceConsumerDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceContractDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceDomainDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProducerDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/dto/ServiceProductionDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.dto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/AcceptHeaderModificationFilter.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/filter/SimpleCORSFilter.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.filter;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscator.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ConnectionPointListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/CooperationListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/InstalledContractListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/LogicalAddressListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceConsumerListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceContractListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceDomainListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProducerListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
+++ b/src/main/java/se/skltp/cooperation/api/v2/listdto/ServiceProductionListDTO.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.listdto;
 

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/AuthController.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/AuthController.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/BasicAuthConfig.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/MyAuthEntryPoint.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/MyAuthEntryPoint.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/MyUserDetailsService.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/MyUserDetailsService.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagement.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Inera.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/Settings.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/Settings.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/UserRepository.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/UserRepository.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/model/ServiceUser.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/model/ServiceUser.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/model/ServiceUserListWrapper.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/model/ServiceUserListWrapper.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/PasswordChange.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/PasswordChange.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule.model.dto;
 
 public class PasswordChange {

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/PasswordCrypto.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/PasswordCrypto.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule.model.dto;
 
 public class PasswordCrypto {

--- a/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/UserData.java
+++ b/src/main/java/se/skltp/cooperation/basicauthmodule/model/dto/UserData.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 //////
 // 2022-05-17, Henrik Augustsson.
 // Nordic Medtest.

--- a/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
+++ b/src/main/java/se/skltp/cooperation/config/MappingConfiguration.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.config;
 

--- a/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
+++ b/src/main/java/se/skltp/cooperation/domain/ConnectionPoint.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/Cooperation.java
+++ b/src/main/java/se/skltp/cooperation/domain/Cooperation.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/InstalledContract.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
+++ b/src/main/java/se/skltp/cooperation/domain/LogicalAddress.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceConsumer.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceContract.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceDomain.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProducer.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
+++ b/src/main/java/se/skltp/cooperation/domain/ServiceProduction.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.domain;
 

--- a/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ConnectionPointRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/CooperationRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/InstalledContractRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/LogicalAddressRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceConsumerRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceContractRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceDomainRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProducerRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
+++ b/src/main/java/se/skltp/cooperation/repository/ServiceProductionRepository.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.repository;
 

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
+++ b/src/main/java/se/skltp/cooperation/service/ConnectionPointService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/CooperationService.java
+++ b/src/main/java/se/skltp/cooperation/service/CooperationService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
+++ b/src/main/java/se/skltp/cooperation/service/DatabaseLoader.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/InstalledContractService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
+++ b/src/main/java/se/skltp/cooperation/service/LogicalAddressService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceConsumerService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceContractService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceDomainService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProducerService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionCriteria.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
+++ b/src/main/java/se/skltp/cooperation/service/ServiceProductionService.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/CooperationServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/InstalledContractServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImpl.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.service.impl;
 
 import java.util.List;

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceContractServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceDomainServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
+++ b/src/main/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImpl.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/main/java/se/skltp/cooperation/util/ControllerUtils.java
+++ b/src/main/java/se/skltp/cooperation/util/ControllerUtils.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.util;
 
 import java.util.ArrayList;

--- a/src/main/java/se/skltp/cooperation/util/TimeDiffUtil.java
+++ b/src/main/java/se/skltp/cooperation/util/TimeDiffUtil.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.util;
 
 import java.time.Duration;

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   main:
     banner-mode: off

--- a/src/main/resources/static/doc/index.html
+++ b/src/main/resources/static/doc/index.html
@@ -1,25 +1,3 @@
-<!--
-
-    Copyright (c) 2026 Inera.
-
-
-    This file is part of SKLTP.
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
--->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/src/main/resources/static/doc/index_v2.html
+++ b/src/main/resources/static/doc/index_v2.html
@@ -1,25 +1,3 @@
-<!--
-
-    Copyright (c) 2026 Inera.
-
-
-    This file is part of SKLTP.
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
--->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/src/test/java/se/skltp/cooperation/ApplicationTest.java
+++ b/src/test/java/se/skltp/cooperation/ApplicationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation;
 

--- a/src/test/java/se/skltp/cooperation/api/TestUtil.java
+++ b/src/test/java/se/skltp/cooperation/api/TestUtil.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api;
 

--- a/src/test/java/se/skltp/cooperation/api/Version1GoneTest.java
+++ b/src/test/java/se/skltp/cooperation/api/Version1GoneTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api;
 
 import org.apache.catalina.security.SecurityConfig;

--- a/src/test/java/se/skltp/cooperation/api/info/ControllerLoggerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/info/ControllerLoggerTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import jakarta.servlet.ServletContext;

--- a/src/test/java/se/skltp/cooperation/api/info/ServletMappingLoggerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/info/ServletMappingLoggerTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import jakarta.servlet.ServletContext;

--- a/src/test/java/se/skltp/cooperation/api/info/WebServerInfoLoggerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/info/WebServerInfoLoggerTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.api.info;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ConnectionPointControllerTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/CooperationControllerTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/InstalledContractControllerTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/controller/ServiceConsumerControllerTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.controller;
 

--- a/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
+++ b/src/test/java/se/skltp/cooperation/api/v2/format/HTTPObfuscatorTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.api.v2.format;
 

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/ApplicationAuthenticationTests.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/ApplicationAuthenticationTests.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/AuthControllerTest.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/AuthControllerTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/MyUserDetailsServiceTest.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/MyUserDetailsServiceTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
+++ b/src/test/java/se/skltp/cooperation/basicauthmodule/ServiceUserManagementTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.basicauthmodule;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaBuilder.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/CooperationCriteriaTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
+++ b/src/test/java/se/skltp/cooperation/service/ServiceConsumerCriteriaTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ConnectionPointServiceImplTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/CooperationServiceImplTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/InstalledContractServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/LogicalAdressServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceConsumerServiceImplTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceContractServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProducerServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
+++ b/src/test/java/se/skltp/cooperation/service/impl/ServiceProductionServiceImplIntegrationTest.java
@@ -1,7 +1,9 @@
-/**
- * Copyright (c) 2015-2026 Inera.
- * * This library is free software under the GNU Lesser General Public License v2.1.
- * Refer to the full license files at the project root.
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
  */
 package se.skltp.cooperation.service.impl;
 

--- a/src/test/java/se/skltp/cooperation/util/ControllerUtilsTest.java
+++ b/src/test/java/se/skltp/cooperation/util/ControllerUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2015-2026 Inera.
+ * Copyright owner URL: https://www.inera.se/
+ * TAK-API (Cooperation) overview page: https://inera.atlassian.net/wiki/spaces/NTJPP/pages/3359539201/Ineras+Informationstj+nster
+ * This library is free software under the GNU Lesser General Public License v2.1 or later.
+ * Please refer to the full license files at the project root.
+ */
 package se.skltp.cooperation.util;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
- updated spring boot 3.5.12 to 3.5.16.
- smaller updates to jacoco, ecs-logging, maven-release.
- Modernized Mycila license plugin from 1.10 to 5.0.0 (10 year jump). It had been left on deprecated source-coordinates. -- Re-did license setup and automation.
-- Ran plugin to refresh license headers.
-- Also touched up license markdown file.